### PR TITLE
Add image attribution

### DIFF
--- a/_data/gallery.yml
+++ b/_data/gallery.yml
@@ -25,6 +25,7 @@
 - title: Moose calves in Sweden
   description: These moose calf twins are around 4-6 weeks old, and their mother is close by.
   href: /assets/camtraps/moose-slu-R3.jpg
+  by: SCANDCAM & SLU
 - title: Hasel grouse in Bavarian National Park, Germany
   description: This small grouse species is rarely seen, despite it rather colorful plumage as it is very secretive and likes dense forest.
   href: /assets/camtraps/hasel-grouse-germany.jpeg

--- a/_layouts/gallery.html
+++ b/_layouts/gallery.html
@@ -1,12 +1,7 @@
 ---
 layout: default
+remark: see _custom.scss for styling
 ---
-
-<style>
-  .carousel-caption {
-    background: rgba(0, 0, 0, 0.5);
-  }
-</style>
 
 {{ content }}
 
@@ -17,7 +12,7 @@ layout: default
     {% for file in files %}
       <div class="carousel-item{% if forloop.first %} active{% endif %}">
         <img class="d-block w-100" src="{{ file.href }}" alt="{{ med.timestamp }}">
-        <div class="carousel-caption d-none d-md-block">
+        <div class="caption">
           <h5>{{ file.title }}</h5>
           <p>{{ file.description }}</p>
         </div>

--- a/_layouts/gallery.html
+++ b/_layouts/gallery.html
@@ -7,13 +7,13 @@ remark: see _custom.scss for styling
 
 {% assign files = site.data.gallery %}
 
-<div id="carousel" class="carousel slide carousel-fade" data-bs-ride="carousel" data-bs-keyboard="false" data-bs-interval="5000">
+<div id="carousel" class="carousel slide carousel-fade" data-bs-ride="carousel" data-bs-keyboard="false" data-bs-interval="7000">
   <div class="carousel-inner">
     {% for file in files %}
       <div class="carousel-item{% if forloop.first %} active{% endif %}">
         <img class="d-block w-100" src="{{ file.href }}" alt="{{ med.timestamp }}">
         <div class="caption">
-          <h5>{{ file.title }}</h5>
+          <h4>{{ file.title }}</h4>
           <p>{{ file.description }}</p>
         </div>
       </div>

--- a/_layouts/gallery.html
+++ b/_layouts/gallery.html
@@ -15,6 +15,9 @@ remark: see _custom.scss for styling
         <div class="caption">
           <h4>{{ file.title }}</h4>
           <p>{{ file.description }}</p>
+          {% if file.by %}
+            <p class="attribution">Image by {{ file.by }}</p>
+          {% endif %}
         </div>
       </div>
     {% endfor %}

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -6,5 +6,9 @@
     font-family: $font-family-base;
     padding: 0.5rem;
     text-align: center;
+    .attribution {
+        color: darken($white, 25);
+        font-size: 80%;
+    }
   }
 }

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -1,0 +1,10 @@
+// Custom style for gallery.html
+.carousel-inner {
+  .caption {
+    background: $dark;
+    color: $white;
+    font-family: $font-family-base;
+    padding: 0.5rem;
+    text-align: center;
+  }
+}

--- a/pages/about.md
+++ b/pages/about.md
@@ -1,6 +1,8 @@
 ---
 title: About
-background: /assets/backgrounds/roedeer-trondheim.jpg
+background:
+  img: /assets/backgrounds/roedeer-trondheim.jpg
+  by: INN
 toc: true
 permalink: /about/
 ---

--- a/pages/home.md
+++ b/pages/home.md
@@ -2,7 +2,9 @@
 layout: home
 title: BIG_PICTURE
 description: Sharing camera trap data to improve wildlife monitoring
-background: /assets/backgrounds/moose-slu-R3.jpg
+background:
+  img: /assets/backgrounds/moose-slu-R3.jpg
+  by: SCANDCAM & SLU
 toc: true
 permalink: /
 ---

--- a/pages/partners.md
+++ b/pages/partners.md
@@ -7,13 +7,7 @@ permalink: /partners/
 ---
 
 <style>
-  .content {
-    table {
-      img {
-        width: 100px;
-      }
-    }
-  }
+.content table img { width: 100px; }
 </style>
 
 ## Overview


### PR DESCRIPTION
Hi @pkaczensky, in this PR I have

- Added the credit for 2 background images (home and about)
- Fixed #7 
- Made sure the caption appears below not on top of the image in the gallery
- And I updated the layout so an image credit can be added for a gallery image.

Before accepting this PR, can you add the image credits for the gallery to this file: https://github.com/camera-traps/wildlifecamera.eu/blob/credit/_data/gallery.yml

You can do so by adding `by` for an image, like here:

https://github.com/camera-traps/wildlifecamera.eu/blob/4195f9e76d5cf9b41bbd52cc7266a01bb91143a7/_data/gallery.yml#L25-L28

 