### PR TITLE
Don't float second header

### DIFF
--- a/pages/home.md
+++ b/pages/home.md
@@ -10,11 +10,13 @@ permalink: /
 
 ## What do we want to do?
 
-![What do we want to do](/assets/images/want-we-want.png){:.w-50 .float-start .me-2}
+<div markdown="1" class="clearfix">
+![What do we want to do](/assets/images/want-we-want.png){:.w-50 .float-end}
 
 The main objective of the BIG_PICTURE project is to bring together the enormous amount of species data that is collected by the thousands of wildlife camera traps (automatic cameras) distributed across Europe by professional researchers, citizen scientists and other private individuals.
 
 By developing the appropriate electronic infrastructure (databases and artificial intelligence-driven image processing capability) and statistical tools for data analysis, the BIG_PICTURE project will facilitate the sharing, integration and joint analysis of data collected by many different institutions, allowing continental-scale assessments of species’ status.
+</div>
 
 ## Why is this relevant?
 


### PR DESCRIPTION
Fix #25

This is how it will look on very wide screens:

<img width="483" alt="Screenshot 2025-04-10 at 17 30 30" src="https://github.com/user-attachments/assets/2b70dcb7-29e9-48a5-831b-72ddf68156d1" />

- The image is on right now
- The second header will always start below image